### PR TITLE
Change contact form email

### DIFF
--- a/_config.build.yml
+++ b/_config.build.yml
@@ -19,7 +19,7 @@ source: 'src'
 destination: 'serve'
 
 # url for the form "action" on submit(#shoov-trial-form).
-trial_form_action: //formspree.io/info+shoov@gizra.com
+trial_form_action: //formspree.io/sales@gizra.com
 
 # Redirect url after form submittion(#shoov-trial-form).
 trial_form_redirect: http://www.shoov.io/?sent=true

--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ highlighter: true
 debug_responsive: false
 
 # url for the form "action" on submit(#shoov-trial-form).
-trial_form_action: //formspree.io/yaron@gizra.com
+trial_form_action: //formspree.io/sales@gizra.com
 
 # Redirect url after form submittion(#shoov-trial-form).
 trial_form_redirect: http://localhost:3000/?sent=true


### PR DESCRIPTION
Changes contact form email to sales@gizra.com.

@amitaibu mention me when/if committing, because I believe the form needs to be reactivated with formspree.